### PR TITLE
Add order history and returned orders methods

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"hw-1/services"
 	"hw-1/storage"
 	"time"
@@ -15,4 +16,20 @@ func main() {
 	var service services.OrderServiceInterface = services.New(store)
 
 	service.AcceptOrder(10, 15, time.Now().Add(time.Hour))
+
+	// Call GetOrderHistory method and print the result
+	orderHistory, err := service.GetOrderHistory(10)
+	if err != nil {
+		fmt.Println("Error fetching order history:", err)
+	} else {
+		fmt.Println("Order History:", orderHistory)
+	}
+
+	// Call GetReturnedOrders method and print the result
+	returnedOrders, err := service.GetReturnedOrders()
+	if err != nil {
+		fmt.Println("Error fetching returned orders:", err)
+	} else {
+		fmt.Println("Returned Orders:", returnedOrders)
+	}
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,21 +1,238 @@
 package main
 
 import (
+	"flag"
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
 	"hw-1/services"
 	"hw-1/storage"
-	"time"
 )
+
+type command string
+
+const (
+	AcceptOrderCommand   command = "accept-order"
+	ReturnOrderCommand   command = "return-order"
+	ProcessOrdersCommand command = "process-orders"
+	ListOrdersCommand    command = "list-orders"
+	ListReturnsCommand   command = "list-returns"
+	OrderHistoryCommand  command = "order-history"
+	HelpCommand          command = "help"
+)
+
+const helpMessage = `Доступные команды:
+
+1. Принять заказ от курьера
+   Команда: accept-order --order-id <ID> --receiver-id <ID> --storage-duration <DAYS>
+   Описание: Принимает заказ от курьера и сохраняет его в файл.
+   Аргументы:
+     --order-id          Идентификатор заказа (обязательный).
+     --receiver-id       Идентификатор получателя (обязательный).
+     --storage-duration  Срок хранения заказа в днях (обязательный).
+   Пример:
+     accept-order --order-id 123 --receiver-id 456 --storage-duration 7
+
+2. Вернуть заказ курьеру
+   Команда: return-order --order-id <ID>
+   Описание: Возвращает заказ курьеру, если срок хранения истек и заказ не был выдан клиенту.
+   Аргументы:
+     --order-id          Идентификатор заказа (обязательный).
+   Пример:
+     return-order --order-id 123
+
+3. Выдать заказы и принять возвраты клиента
+   Команда: process-orders --client-id <ID> --order-ids <ID1,ID2,...> --action <ACTION>
+   Описание: Выдает заказы клиенту или принимает возвраты.
+   Аргументы:
+     --client-id         Идентификатор клиента (обязательный).
+     --order-ids         Список идентификаторов заказов через запятую (обязательный).
+     --action            Действие: "issue" (выдать) или "return" (принять возврат) (обязательный).
+   Пример:
+     process-orders --client-id 456 --order-ids 123,789 --action issue
+
+4. Получить список заказов
+   Команда: list-orders --client-id <ID> [--limit <N>] [--status <STATUS>]
+   Описание: Возвращает список заказов для указанного клиента.
+   Аргументы:
+     --client-id         Идентификатор клиента (обязательный).
+     --limit             Ограничить количество заказов (опционально).
+     --status            Фильтр по статусу заказа (например, "in_storage") (опционально).
+   Пример:
+     list-orders --client-id 456 --limit 10 --status in_storage
+
+5. Получить список возвратов
+   Команда: list-returns [--page <N>] [--per-page <N>]
+   Описание: Возвращает список возвратов с постраничной пагинацией.
+   Аргументы:
+     --page              Номер страницы (по умолчанию 1).
+     --per-page          Количество возвратов на странице (по умолчанию 10).
+   Пример:
+     list-returns --page 2 --per-page 5
+
+6. Получить историю заказов
+   Команда: order-history --client-id <ID>
+   Описание: Возвращает историю заказов в порядке изменения их последнего состояния.
+   Аргументы:
+     --client-id         Идентификатор клиента (обязательный).
+   Пример:
+     order-history --client-id 456
+
+7. Помощь
+   Команда: help
+   Описание: Выводит список доступных команд и их описание.
+   Пример:
+     help`
 
 func main() {
 	store, err := storage.NewJsonStorage("data.json")
 	if err != nil {
 		panic(err)
 	}
-
 	var service services.OrderServiceInterface = services.New(store)
+	_ = service
 
-	service.AcceptOrder(10, 15, time.Now().Add(time.Hour))
+	mainArg := command(os.Args[1])
+
+	switch mainArg {
+	case HelpCommand:
+		fmt.Println(helpMessage)
+		return
+
+	case AcceptOrderCommand:
+		orderID := flag.Uint("order-id", 0, "orderID")
+		receiverID := flag.Uint("receiver-id", 0, "receiverID")
+		storageDuration := flag.Uint("storage-duration", 0, "duration")
+
+		flag.Parse()
+
+		if flag.NFlag() != 3 || *orderID == 0 || *receiverID == 0 || *storageDuration == 0 {
+			fmt.Println("Invalid arguments")
+			return
+		}
+
+		if err := service.AcceptOrder(*orderID, *receiverID, time.Now().Add(time.Duration(*storageDuration)*time.Hour*24)); err != nil {
+			fmt.Println("Error accepting order:", err)
+		}
+
+		fmt.Println("Order accepted successfully")
+		return
+
+	case ReturnOrderCommand:
+		var orderID = flag.Uint("order-id", 0, "orderID")
+		flag.Parse()
+
+		if flag.NFlag() != 1 || *orderID == 0 {
+			fmt.Println("Invalid arguments")
+			return
+		}
+
+		if err := service.ReturnOrderToCourier(*orderID); err != nil {
+			fmt.Println("Error returning order:", err)
+		}
+
+		fmt.Println("Order returned successfully")
+		return
+
+	case ProcessOrdersCommand:
+		clientID := flag.Uint("client-id", 0, "clientID")
+		orderIDs := flag.String("order-ids", "", "orderIDs")
+		action := flag.String("action", "", "action")
+		flag.Parse()
+
+		if flag.NFlag() < 3 {
+			fmt.Println("Invalid arguments")
+			return
+		}
+		if *action != "return" && *action != "issue" {
+			fmt.Println("Invalid action")
+			return
+		}
+
+		orders := strings.Split(*orderIDs, ",")
+		var ids []uint = make([]uint, len(orders))
+
+		for i, _ := range orders {
+			id, err := strconv.Atoi(orders[i])
+			if err != nil {
+				fmt.Println("Invalid order ID:", orders[i])
+				return
+			}
+			ids[i] = uint(id)
+		}
+		switch *action {
+		case "return":
+			if err := service.AcceptReturns(*clientID, ids...); err != nil {
+				fmt.Println("Error accepting orders:", err)
+				return
+			}
+			fmt.Println("Заказы успешно приняты")
+			return
+		case "issue":
+			if err := service.DeliverOrders(*clientID, ids...); err != nil {
+				fmt.Println("Error returning orders:", err)
+				return
+			}
+			fmt.Println("Заказы успешно выданы")
+			return
+		}
+		return
+	case ListOrdersCommand:
+		customerID := flag.Uint("client-id", 0, "clientID")
+		limit := flag.Int("limit", 0, "limit")
+		flag.Parse()
+
+		if *customerID == 0 {
+			fmt.Println("Invalid client ID")
+			return
+		}
+
+		orders, err := service.GetCustomerOrders(*customerID, *limit)
+		if err != nil {
+			fmt.Println("Error listing orders:", err)
+			return
+		}
+		fmt.Println("Orders:", orders)
+		return
+
+	case ListReturnsCommand:
+		returns, err := service.GetReturnedOrders()
+		if err != nil {
+			fmt.Println("Error listing returns:", err)
+			return
+		}
+		fmt.Println("Returns:", returns)
+		return
+
+	case OrderHistoryCommand:
+		customerID := flag.Int("client-id", 0, "clientID")
+		flag.Parse()
+
+		if *customerID == 0 {
+			fmt.Println("Invalid client ID")
+			return
+		}
+
+		history, err := service.GetOrderHistory(*customerID)
+		if err != nil {
+			fmt.Println("Error listing order history:", err)
+			return
+		}
+		fmt.Println("Order History:", history)
+		return
+
+	default:
+		fmt.Println("Invalid command")
+		fmt.Println(helpMessage)
+		return
+	}
+}
+
+/*
+service.AcceptOrder(10, 15, time.Now().Add(time.Hour))
 
 	// Call GetOrderHistory method and print the result
 	orderHistory, err := service.GetOrderHistory(10)
@@ -32,4 +249,4 @@ func main() {
 	} else {
 		fmt.Println("Returned Orders:", returnedOrders)
 	}
-}
+*/

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,10 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strconv"
-	"strings"
-	"time"
-
+	"hw-1/handlers"
 	"hw-1/services"
 	"hw-1/storage"
 )
@@ -103,27 +100,27 @@ func main() {
 		return
 
 	case AcceptOrderCommand:
-		handleAcceptOrder(service)
+		handlers.HandleAcceptOrder(service)
 		return
 
 	case ReturnOrderCommand:
-		handleReturnOrder(service)
+		handlers.HandleReturnOrder(service)
 		return
 
 	case ProcessOrdersCommand:
-		handleProcessOrders(service)
+		handlers.HandleProcessOrders(service)
 		return
 
 	case ListOrdersCommand:
-		handleListOrders(service)
+		handlers.HandleListOrders(service)
 		return
 
 	case ListReturnsCommand:
-		handleListReturns(service)
+		handlers.HandleListReturns(service)
 		return
 
 	case OrderHistoryCommand:
-		handleOrderHistory(service)
+		handlers.HandleOrderHistory(service)
 		return
 
 	default:
@@ -131,133 +128,4 @@ func main() {
 		fmt.Println(helpMessage)
 		return
 	}
-}
-
-// handleAcceptOrder processes the accept-order command
-func handleAcceptOrder(service services.OrderServiceInterface) {
-	orderID := flag.Uint("order-id", 0, "orderID")
-	receiverID := flag.Uint("receiver-id", 0, "receiverID")
-	storageDuration := flag.Uint("storage-duration", 0, "duration")
-
-	flag.Parse()
-
-	if flag.NFlag() != 3 || *orderID == 0 || *receiverID == 0 || *storageDuration == 0 {
-		fmt.Println("Invalid arguments")
-		return
-	}
-
-	if err := service.AcceptOrder(*orderID, *receiverID, time.Now().Add(time.Duration(*storageDuration)*time.Hour*24)); err != nil {
-		fmt.Println("Error accepting order:", err)
-	}
-
-	fmt.Println("Order accepted successfully")
-}
-
-// handleReturnOrder processes the return-order command
-func handleReturnOrder(service services.OrderServiceInterface) {
-	var orderID = flag.Uint("order-id", 0, "orderID")
-	flag.Parse()
-
-	if flag.NFlag() != 1 || *orderID == 0 {
-		fmt.Println("Invalid arguments")
-		return
-	}
-
-	if err := service.ReturnOrderToCourier(*orderID); err != nil {
-		fmt.Println("Error returning order:", err)
-	}
-
-	fmt.Println("Order returned successfully")
-}
-
-// handleProcessOrders processes the process-orders command
-func handleProcessOrders(service services.OrderServiceInterface) {
-	clientID := flag.Uint("client-id", 0, "clientID")
-	orderIDs := flag.String("order-ids", "", "orderIDs")
-	action := flag.String("action", "", "action")
-	flag.Parse()
-
-	if flag.NFlag() < 3 {
-		fmt.Println("Invalid arguments")
-		return
-	}
-	if *action != "return" && *action != "issue" {
-		fmt.Println("Invalid action")
-		return
-	}
-
-	orders := strings.Split(*orderIDs, ",")
-	var ids []uint = make([]uint, len(orders))
-
-	for i, _ := range orders {
-		id, err := strconv.Atoi(orders[i])
-		if err != nil {
-			fmt.Println("Invalid order ID:", orders[i])
-			return
-		}
-		ids[i] = uint(id)
-	}
-	switch *action {
-	case "return":
-		if err := service.AcceptReturns(*clientID, ids...); err != nil {
-			fmt.Println("Error accepting orders:", err)
-			return
-		}
-		fmt.Println("Заказы успешно приняты")
-		return
-	case "issue":
-		if err := service.DeliverOrders(*clientID, ids...); err != nil {
-			fmt.Println("Error returning orders:", err)
-			return
-		}
-		fmt.Println("Заказы успешно выданы")
-		return
-	}
-}
-
-// handleListOrders processes the list-orders command
-func handleListOrders(service services.OrderServiceInterface) {
-	customerID := flag.Uint("client-id", 0, "clientID")
-	limit := flag.Int("limit", 0, "limit")
-	flag.Parse()
-
-	if *customerID == 0 {
-		fmt.Println("Invalid client ID")
-		return
-	}
-
-	orders, err := service.GetCustomerOrders(*customerID, *limit)
-	if err != nil {
-		fmt.Println("Error listing orders:", err)
-		return
-	}
-	fmt.Println("Orders:", orders)
-}
-
-// handleListReturns processes the list-returns command
-func handleListReturns(service services.OrderServiceInterface) {
-	returns, err := service.GetReturnedOrders()
-	if err != nil {
-		fmt.Println("Error listing returns:", err)
-		return
-	}
-	fmt.Println("Returns:", returns)
-}
-
-// handleOrderHistory processes the order-history command
-func handleOrderHistory(service services.OrderServiceInterface) {
-	customerID := flag.Int("client-id", 0, "clientID")
-	flag.Parse()
-
-	if *customerID == 0 {
-		fmt.Println("Invalid client ID")
-		return
-	}
-
-	history, err := service.GetOrderHistory(*customerID)
-	if err != nil {
-		fmt.Println("Error listing order history:", err)
-		return
-	}
-	fmt.Println("Order History:", history)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module hw-1
+module github.com/Loxis88/hw-1
 
 go 1.24.0

--- a/handlers/accept_order.go
+++ b/handlers/accept_order.go
@@ -1,0 +1,29 @@
+package handlers
+
+import (
+	"flag"
+	"fmt"
+	"time"
+
+	"hw-1/services"
+)
+
+// handleAcceptOrder processes the accept-order command
+func HandleAcceptOrder(service services.OrderServiceInterface) {
+	orderID := flag.Uint("order-id", 0, "orderID")
+	receiverID := flag.Uint("receiver-id", 0, "receiverID")
+	storageDuration := flag.Uint("storage-duration", 0, "duration")
+
+	flag.Parse()
+
+	if flag.NFlag() != 3 || *orderID == 0 || *receiverID == 0 || *storageDuration == 0 {
+		fmt.Println("Invalid arguments")
+		return
+	}
+
+	if err := service.AcceptOrder(*orderID, *receiverID, time.Now().Add(time.Duration(*storageDuration)*time.Hour*24)); err != nil {
+		fmt.Println("Error accepting order:", err)
+	}
+
+	fmt.Println("Order accepted successfully")
+}

--- a/handlers/accept_order.go
+++ b/handlers/accept_order.go
@@ -8,7 +8,7 @@ import (
 	"hw-1/services"
 )
 
-// handleAcceptOrder processes the accept-order command
+// HandleAcceptOrder processes the accept-order command
 func HandleAcceptOrder(service services.OrderServiceInterface) {
 	orderID := flag.Uint("order-id", 0, "orderID")
 	receiverID := flag.Uint("receiver-id", 0, "receiverID")

--- a/handlers/list_orders.go
+++ b/handlers/list_orders.go
@@ -7,7 +7,7 @@ import (
 	"hw-1/services"
 )
 
-// handleListOrders processes the list-orders command
+// HandleListOrders processes the list-orders command
 func HandleListOrders(service services.OrderServiceInterface) {
 	customerID := flag.Uint("client-id", 0, "clientID")
 	limit := flag.Int("limit", 0, "limit")

--- a/handlers/list_orders.go
+++ b/handlers/list_orders.go
@@ -1,0 +1,27 @@
+package handlers
+
+import (
+	"flag"
+	"fmt"
+
+	"hw-1/services"
+)
+
+// handleListOrders processes the list-orders command
+func HandleListOrders(service services.OrderServiceInterface) {
+	customerID := flag.Uint("client-id", 0, "clientID")
+	limit := flag.Int("limit", 0, "limit")
+	flag.Parse()
+
+	if *customerID == 0 {
+		fmt.Println("Invalid client ID")
+		return
+	}
+
+	orders, err := service.GetCustomerOrders(*customerID, *limit)
+	if err != nil {
+		fmt.Println("Error listing orders:", err)
+		return
+	}
+	fmt.Println("Orders:", orders)
+}

--- a/handlers/list_returns.go
+++ b/handlers/list_returns.go
@@ -1,0 +1,17 @@
+package handlers
+
+import (
+	"fmt"
+
+	"hw-1/services"
+)
+
+// HandleListReturns processes the list-returns command
+func HandleListReturns(service services.OrderServiceInterface) {
+	returns, err := service.GetReturnedOrders()
+	if err != nil {
+		fmt.Println("Error listing returns:", err)
+		return
+	}
+	fmt.Println("Returns:", returns)
+}

--- a/handlers/order_history.go
+++ b/handlers/order_history.go
@@ -1,0 +1,26 @@
+package handlers
+
+import (
+	"flag"
+	"fmt"
+
+	"hw-1/services"
+)
+
+// handleOrderHistory processes the order-history command
+func HandleOrderHistory(service services.OrderServiceInterface) {
+	customerID := flag.Int("client-id", 0, "clientID")
+	flag.Parse()
+
+	if *customerID == 0 {
+		fmt.Println("Invalid client ID")
+		return
+	}
+
+	history, err := service.GetOrderHistory(*customerID)
+	if err != nil {
+		fmt.Println("Error listing order history:", err)
+		return
+	}
+	fmt.Println("Order History:", history)
+}

--- a/handlers/order_history.go
+++ b/handlers/order_history.go
@@ -7,7 +7,7 @@ import (
 	"hw-1/services"
 )
 
-// handleOrderHistory processes the order-history command
+// HandleOrderHistory processes the order-history command
 func HandleOrderHistory(service services.OrderServiceInterface) {
 	customerID := flag.Int("client-id", 0, "clientID")
 	flag.Parse()

--- a/handlers/process_orders.go
+++ b/handlers/process_orders.go
@@ -9,7 +9,7 @@ import (
 	"hw-1/services"
 )
 
-// handleProcessOrders processes the process-orders command
+// HandleProcessOrders processes the process-orders command
 func HandleProcessOrders(service services.OrderServiceInterface) {
 	clientID := flag.Uint("client-id", 0, "clientID")
 	orderIDs := flag.String("order-ids", "", "orderIDs")

--- a/handlers/process_orders.go
+++ b/handlers/process_orders.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"flag"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"hw-1/services"
+)
+
+// handleProcessOrders processes the process-orders command
+func HandleProcessOrders(service services.OrderServiceInterface) {
+	clientID := flag.Uint("client-id", 0, "clientID")
+	orderIDs := flag.String("order-ids", "", "orderIDs")
+	action := flag.String("action", "", "action")
+	flag.Parse()
+
+	if flag.NFlag() < 3 {
+		fmt.Println("Invalid arguments")
+		return
+	}
+	if *action != "return" && *action != "issue" {
+		fmt.Println("Invalid action")
+		return
+	}
+
+	orders := strings.Split(*orderIDs, ",")
+	var ids []uint = make([]uint, len(orders))
+
+	for i, _ := range orders {
+		id, err := strconv.Atoi(orders[i])
+		if err != nil {
+			fmt.Println("Invalid order ID:", orders[i])
+			return
+		}
+		ids[i] = uint(id)
+	}
+	switch *action {
+	case "return":
+		if err := service.AcceptReturns(*clientID, ids...); err != nil {
+			fmt.Println("Error accepting orders:", err)
+			return
+		}
+		fmt.Println("Заказы успешно приняты")
+		return
+	case "issue":
+		if err := service.DeliverOrders(*clientID, ids...); err != nil {
+			fmt.Println("Error returning orders:", err)
+			return
+		}
+		fmt.Println("Заказы успешно выданы")
+		return
+	}
+}

--- a/handlers/return_order.go
+++ b/handlers/return_order.go
@@ -7,7 +7,7 @@ import (
 	"hw-1/services"
 )
 
-// handleReturnOrder processes the return-order command
+// HandleReturnOrder processes the return-order command
 func HandleReturnOrder(service services.OrderServiceInterface) {
 	var orderID = flag.Uint("order-id", 0, "orderID")
 	flag.Parse()

--- a/handlers/return_order.go
+++ b/handlers/return_order.go
@@ -1,0 +1,25 @@
+package handlers
+
+import (
+	"flag"
+	"fmt"
+
+	"hw-1/services"
+)
+
+// handleReturnOrder processes the return-order command
+func HandleReturnOrder(service services.OrderServiceInterface) {
+	var orderID = flag.Uint("order-id", 0, "orderID")
+	flag.Parse()
+
+	if flag.NFlag() != 1 || *orderID == 0 {
+		fmt.Println("Invalid arguments")
+		return
+	}
+
+	if err := service.ReturnOrderToCourier(*orderID); err != nil {
+		fmt.Println("Error returning order:", err)
+	}
+
+	fmt.Println("Order returned successfully")
+}

--- a/services/service.go
+++ b/services/service.go
@@ -14,7 +14,7 @@ type OrderServiceInterface interface {
 	ReturnOrderToCourier(orderID uint) error
 	DeliverOrders(customerID uint, orderIDs ...uint) error
 	AcceptReturns(customerID uint, orderIDs ...uint) error
-	GetCustomerOrders(customerID uint, limit int, inStorageOnly bool) ([]models.Order, error)
+	GetCustomerOrders(customerID uint, limit int) ([]models.Order, error)
 	GetOrderHistory(limit int) ([]models.Order, error)
 	GetReturnedOrders() ([]models.Order, error)
 }
@@ -155,8 +155,8 @@ func (s *OrderService) AcceptReturns(customerID uint, orderIDs ...uint) error {
 	return nil
 }
 
-func (s *OrderService) GetCustomerOrders(customerID uint, limit int, inStorageOnly bool) ([]models.Order, error) {
-	return s.storage.GetOrdersByCustomer(customerID, limit, inStorageOnly), nil
+func (s *OrderService) GetCustomerOrders(customerID uint, limit int) ([]models.Order, error) {
+	return s.storage.GetOrdersByCustomer(customerID, limit), nil
 }
 
 func (s *OrderService) GetOrderHistory(limit int) ([]models.Order, error) {

--- a/services/service.go
+++ b/services/service.go
@@ -8,6 +8,7 @@ import (
 	"hw-1/storage"
 )
 
+// OrderServiceInterface defines the interface for order service operations
 type OrderServiceInterface interface {
 	// Основные операции с заказами
 	AcceptOrder(orderID uint, customerID uint, storageDate time.Time) error
@@ -22,10 +23,12 @@ type OrderServiceInterface interface {
 // Проверка реализации интерфейса
 var _ OrderServiceInterface = (*OrderService)(nil)
 
+// OrderService implements the OrderServiceInterface
 type OrderService struct {
 	storage storage.OrderStorage
 }
 
+// New creates a new instance of OrderService
 func New(storage storage.OrderStorage) OrderServiceInterface {
 	return &OrderService{storage: storage}
 }
@@ -155,18 +158,22 @@ func (s *OrderService) AcceptReturns(customerID uint, orderIDs ...uint) error {
 	return nil
 }
 
+// GetCustomerOrders retrieves orders for a specific customer
 func (s *OrderService) GetCustomerOrders(customerID uint, limit int) ([]models.Order, error) {
 	return s.storage.GetOrdersByCustomer(customerID, limit), nil
 }
 
+// GetOrderHistory retrieves the order history
 func (s *OrderService) GetOrderHistory(limit int) ([]models.Order, error) {
 	return s.storage.GetOrdersHistory(limit)
 }
 
+// GetReturnedOrders retrieves the returned orders
 func (s *OrderService) GetReturnedOrders() ([]models.Order, error) {
 	return s.storage.GetReturnedOrders(), nil
 }
 
+// ReturnedList prints the list of returned orders
 func (s *OrderService) ReturnedList() {
 	orders := s.storage.GetExpiredOrders()
 

--- a/services/service.go
+++ b/services/service.go
@@ -16,6 +16,7 @@ type OrderServiceInterface interface {
 	AcceptReturns(customerID uint, orderIDs ...uint) error
 	GetCustomerOrders(customerID uint, limit int, inStorageOnly bool) ([]models.Order, error)
 	GetOrderHistory(limit int) ([]models.Order, error)
+	GetReturnedOrders() ([]models.Order, error)
 }
 
 // Проверка реализации интерфейса
@@ -156,6 +157,14 @@ func (s *OrderService) AcceptReturns(customerID uint, orderIDs ...uint) error {
 
 func (s *OrderService) GetCustomerOrders(customerID uint, limit int, inStorageOnly bool) ([]models.Order, error) {
 	return s.storage.GetOrdersByCustomer(customerID, limit, inStorageOnly), nil
+}
+
+func (s *OrderService) GetOrderHistory(limit int) ([]models.Order, error) {
+	return s.storage.GetOrdersHistory(limit)
+}
+
+func (s *OrderService) GetReturnedOrders() ([]models.Order, error) {
+	return s.storage.GetReturnedOrders(), nil
 }
 
 func (s *OrderService) ReturnedList() {

--- a/storage/json_storage/storage.go
+++ b/storage/json_storage/storage.go
@@ -53,7 +53,7 @@ func (s *Storage) save() error {
 	return nil
 }
 
-// AddOrder добавляет новый заказ
+// AddOrder adds a new order to the storage
 func (s *Storage) AddOrder(order models.Order) error {
 	if _, err := s.FindOrder(order.ID); err == nil {
 		return fmt.Errorf("order with id %d already exists", order.ID)
@@ -66,6 +66,7 @@ func (s *Storage) AddOrder(order models.Order) error {
 	return nil
 }
 
+// UpdateOrder updates an existing order in the storage
 func (s *Storage) UpdateOrder(order models.Order) error {
 	for i, o := range s.orders {
 		if o.ID == order.ID {
@@ -79,6 +80,7 @@ func (s *Storage) UpdateOrder(order models.Order) error {
 	return fmt.Errorf("order with id %d not found", order.ID)
 }
 
+// DeleteOrder deletes an order from the storage
 func (s *Storage) DeleteOrder(id uint) error {
 	for i, order := range s.orders {
 		if order.ID == id {
@@ -92,10 +94,12 @@ func (s *Storage) DeleteOrder(id uint) error {
 	return fmt.Errorf("order with id %d not found", id)
 }
 
+// GetOrders retrieves all orders from the storage
 func (s *Storage) GetOrders() []models.Order {
 	return s.orders
 }
 
+// GetOrdersByCustomer retrieves orders for a specific customer
 func (s *Storage) GetOrdersByCustomer(customerID uint, lastN int) []models.Order {
 	var result []models.Order
 
@@ -115,6 +119,7 @@ func (s *Storage) GetOrdersByCustomer(customerID uint, lastN int) []models.Order
 	return result
 }
 
+// FindOrder finds an order by its ID
 func (s *Storage) FindOrder(id uint) (*models.Order, error) {
 	for i, order := range s.orders {
 		if order.ID == id {
@@ -124,6 +129,7 @@ func (s *Storage) FindOrder(id uint) (*models.Order, error) {
 	return nil, fmt.Errorf("order with id %d not found", id)
 }
 
+// GetExpiredOrders retrieves orders that have expired
 func (s *Storage) GetExpiredOrders() []models.Order {
 	var expired []models.Order
 	now := time.Now()
@@ -137,6 +143,7 @@ func (s *Storage) GetExpiredOrders() []models.Order {
 	return expired
 }
 
+// GetReturnedOrders retrieves orders that have been returned
 func (s *Storage) GetReturnedOrders() []models.Order {
 	orders := s.GetOrders()
 
@@ -149,16 +156,14 @@ func (s *Storage) GetReturnedOrders() []models.Order {
 	return result
 }
 
+// GetOrdersHistory retrieves the order history
 func (s *Storage) GetOrdersHistory(limit int) ([]models.Order, error) {
-	// Получаем все заказы
 	orders := s.GetOrders()
 
-	// Сортируем по времени обновления (в порядке убывания)
 	sort.Slice(orders, func(i, j int) bool {
 		return orders[i].UpdatedAt.After(orders[j].UpdatedAt)
 	})
 
-	// Применяем лимит
 	if len(orders) > limit {
 		orders = orders[:limit]
 	}

--- a/storage/json_storage/storage.go
+++ b/storage/json_storage/storage.go
@@ -96,12 +96,12 @@ func (s *Storage) GetOrders() []models.Order {
 	return s.orders
 }
 
-func (s *Storage) GetOrdersByCustomer(customerID uint, lastN int, inStorageOnly bool) []models.Order {
+func (s *Storage) GetOrdersByCustomer(customerID uint, lastN int) []models.Order {
 	var result []models.Order
 
 	for _, order := range s.orders {
 		if order.CustomerID == customerID {
-			if inStorageOnly && order.Status != models.StatusNew {
+			if order.Status != models.StatusNew {
 				continue
 			}
 			result = append(result, order)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -6,18 +6,18 @@ import (
 )
 
 type OrderStorage interface {
-    AddOrder(order models.Order) error
-    UpdateOrder(order models.Order) error
-    DeleteOrder(id uint) error
-    GetOrders() []models.Order
-    GetOrdersByCustomer(customerID uint, lastN int, inStorageOnly bool) []models.Order
-    FindOrder(id uint) (*models.Order, error)
-    GetExpiredOrders() []models.Order
-    GetOrdersHistory(limit int) ([]models.Order, error)
-    GetReturnedOrders() []models.Order
+	AddOrder(order models.Order) error
+	UpdateOrder(order models.Order) error
+	DeleteOrder(id uint) error
+	GetOrders() []models.Order
+	GetOrdersByCustomer(customerID uint, lastN int) []models.Order
+	FindOrder(id uint) (*models.Order, error)
+	GetExpiredOrders() []models.Order
+	GetOrdersHistory(limit int) ([]models.Order, error)
+	GetReturnedOrders() []models.Order
 }
 
 // Функция для создания нового хранилища
 func NewJsonStorage(path string) (OrderStorage, error) {
-    return json_storage.New(path)
+	return json_storage.New(path)
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -13,6 +13,8 @@ type OrderStorage interface {
     GetOrdersByCustomer(customerID uint, lastN int, inStorageOnly bool) []models.Order
     FindOrder(id uint) (*models.Order, error)
     GetExpiredOrders() []models.Order
+    GetOrdersHistory(limit int) ([]models.Order, error)
+    GetReturnedOrders() []models.Order
 }
 
 // Функция для создания нового хранилища


### PR DESCRIPTION
Add new methods to fetch order history and returned orders.

* **services/service.go**
  - Add `GetOrderHistory` method to `OrderServiceInterface` and implement it in `OrderService`.
  - Add `GetReturnedOrders` method to `OrderServiceInterface` and implement it in `OrderService`.

* **cmd/main.go**
  - Add code to call `GetOrderHistory` method of `OrderService` and print the result.
  - Add code to call `GetReturnedOrders` method of `OrderService` and print the result.

* **storage/storage.go**
  - Add `GetOrdersHistory` method to `OrderStorage` interface.
  - Add `GetReturnedOrders` method to `OrderStorage` interface.

